### PR TITLE
Update index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1211,7 +1211,7 @@ cmbot.prototype.autodj = function() {
 		log("Setting timer to autodj");
 		cmbot.session.timers.autodj = setTimeout(function() {
 			// Make sure the previous conditions are still true before actually dj'ing
-			if(cmbot.session.max_djs - cmbot.session.djs.length >= 2 && !cmbot.session.djing && cmbot.q.getQueueLength(true) == 0) {
+			if(cmbot.session.max_djs - cmbot.session.djs.length >= cmbot.options.autodj_threshold && !cmbot.session.djing && cmbot.q.getQueueLength(true) == 0) {
 				log("Autodj'ing!");
 				cmbot.bot.addDj(function(result) {
 					if(result.success) {


### PR DESCRIPTION
making empty DJ slots a variable in order to have autodj kick in a _user setting_ number of empty DJ slots. Also need to add the setting to your Setup.js file:

autodj_threshold: 2, // Number of open DJ spots needed for the bot to Auto DJ, requires autodj: true
